### PR TITLE
画像アップロード修正プログラム

### DIFF
--- a/app/assets/javascripts/items.js
+++ b/app/assets/javascripts/items.js
@@ -1,4 +1,9 @@
 $(function(){
+  // 編集画面表示時、プレビューが5枚あったらラベルを隠す
+  let countEditPreviews = $('.previewBox').length;
+  if (countEditPreviews >= 5){
+    $('.dropBox').hide();
+  }
   // 画像用のinputを生成する関数
   const buildFileField = (index)=> {
     const html = `<div data-index="${index}" class="js-file_group">


### PR DESCRIPTION
# What
- items.js読み込み時に画像を格納しているBoxの長さをカウント
- 5以上ある場合は画像投稿ボタンを非表示にする

# Why
画像が5枚選択されている状態で商品詳細編集時を開いた場合、6枚以降も登録できるようになっていたので修正プログラムを適用
