### PR TITLE
[add]配送先のウィザード登録

### DIFF
--- a/app/controllers/users/confirmations_controller.rb
+++ b/app/controllers/users/confirmations_controller.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+class Users::ConfirmationsController < Devise::ConfirmationsController
+  # GET /resource/confirmation/new
+  # def new
+  #   super
+  # end
+
+  # POST /resource/confirmation
+  # def create
+  #   super
+  # end
+
+  # GET /resource/confirmation?confirmation_token=abcdef
+  # def show
+  #   super
+  # end
+
+  # protected
+
+  # The path used after resending confirmation instructions.
+  # def after_resending_confirmation_instructions_path_for(resource_name)
+  #   super(resource_name)
+  # end
+
+  # The path used after confirmation.
+  # def after_confirmation_path_for(resource_name, resource)
+  #   super(resource_name, resource)
+  # end
+end

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
+  # You should configure your model like this:
+  # devise :omniauthable, omniauth_providers: [:twitter]
+
+  # You should also create an action method in this controller like this:
+  # def twitter
+  # end
+
+  # More info at:
+  # https://github.com/heartcombo/devise#omniauth
+
+  # GET|POST /resource/auth/twitter
+  # def passthru
+  #   super
+  # end
+
+  # GET|POST /users/auth/twitter/callback
+  # def failure
+  #   super
+  # end
+
+  # protected
+
+  # The path used when OmniAuth fails
+  # def after_omniauth_failure_path_for(scope)
+  #   super(scope)
+  # end
+end

--- a/app/controllers/users/passwords_controller.rb
+++ b/app/controllers/users/passwords_controller.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+class Users::PasswordsController < Devise::PasswordsController
+  # GET /resource/password/new
+  # def new
+  #   super
+  # end
+
+  # POST /resource/password
+  # def create
+  #   super
+  # end
+
+  # GET /resource/password/edit?reset_password_token=abcdef
+  # def edit
+  #   super
+  # end
+
+  # PUT /resource/password
+  # def update
+  #   super
+  # end
+
+  # protected
+
+  # def after_resetting_password_path_for(resource)
+  #   super(resource)
+  # end
+
+  # The path used after sending reset password instructions
+  # def after_sending_reset_password_instructions_path_for(resource_name)
+  #   super(resource_name)
+  # end
+end

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -1,0 +1,90 @@
+# frozen_string_literal: true
+
+class Users::RegistrationsController < Devise::RegistrationsController
+  # before_action :configure_sign_up_params, only: [:create]
+  # before_action :configure_account_update_params, only: [:update]
+
+  # GET /resource/sign_up
+  def new
+    @user = User.new
+  end
+
+  # POST /resource
+  def create_destination
+    @user = User.new(session["devise.regist_data"]["user"])
+    @destination = Destination.new(address_params)
+    unless @destination.valid?
+      flash.now[:alert] = @destination.errors.full_messages
+      render :new_destination and return
+    end
+    @user.build_destination(@destination.attributes)
+    @user.save
+    session["devise.regist_data"]["user"].clear
+    sign_in(:user, @user)
+    redirect_to root_path, notice: 'アカウントを登録しました'
+  end
+
+  def create
+    @user = User.new(sign_up_params)
+    unless @user.valid?
+      flash.now[:alert] = @user.errors.full_messages
+      render :new and return
+    end
+    session["devise.regist_data"] = {user: @user.attributes}
+    session["devise.regist_data"][:user]["password"] = params[:user][:password]
+    @destination = @user.build_destination
+    render :new_destination
+  end
+
+  
+
+  # GET /resource/edit
+  # def edit
+  #   super
+  # end
+
+  # PUT /resource
+  # def update
+  #   super
+  # end
+
+  # DELETE /resource
+  # def destroy
+  #   super
+  # end
+
+  # GET /resource/cancel
+  # Forces the session data which is usually expired after sign
+  # in to be expired now. This is useful if the user wants to
+  # cancel oauth signing in/up in the middle of the process,
+  # removing all OAuth session data.
+  # def cancel
+  #   super
+  # end
+
+  protected
+
+  def address_params
+    params.require(:destination).permit(:destination_family_name, :destination_first_name, :destination_family_name_kana, :destination_first_name_kana, :post_code, :prefecture, :city, :address, :building_name, :phone_number)
+  end
+
+  # If you have extra params to permit, append them to the sanitizer.
+  # def configure_sign_up_params
+  #   devise_parameter_sanitizer.permit(:sign_up, keys: [:attribute])
+  # end
+
+  # If you have extra params to permit, append them to the sanitizer.
+  # def configure_account_update_params
+  #   devise_parameter_sanitizer.permit(:account_update, keys: [:attribute])
+  # end
+
+  # The path used after sign up.
+  # def after_sign_up_path_for(resource)
+  #   super(resource)
+  # end
+
+  # The path used after sign up for inactive accounts.
+  # def after_inactive_sign_up_path_for(resource)
+  #   super(resource)
+  # end
+end

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+class Users::SessionsController < Devise::SessionsController
+  # before_action :configure_sign_in_params, only: [:create]
+
+  # GET /resource/sign_in
+  # def new
+  #   super
+  # end
+
+  # POST /resource/sign_in
+  # def create
+  #   super
+  # end
+
+  # DELETE /resource/sign_out
+  # def destroy
+  #   super
+  # end
+
+  # protected
+
+  # If you have extra params to permit, append them to the sanitizer.
+  # def configure_sign_in_params
+  #   devise_parameter_sanitizer.permit(:sign_in, keys: [:attribute])
+  # end
+end

--- a/app/controllers/users/unlocks_controller.rb
+++ b/app/controllers/users/unlocks_controller.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+class Users::UnlocksController < Devise::UnlocksController
+  # GET /resource/unlock/new
+  # def new
+  #   super
+  # end
+
+  # POST /resource/unlock
+  # def create
+  #   super
+  # end
+
+  # GET /resource/unlock?unlock_token=abcdef
+  # def show
+  #   super
+  # end
+
+  # protected
+
+  # The path used after sending unlock password instructions
+  # def after_sending_unlock_instructions_path_for(resource)
+  #   super(resource)
+  # end
+
+  # The path used after unlocking the resource
+  # def after_unlock_path_for(resource)
+  #   super(resource)
+  # end
+end

--- a/app/models/destination.rb
+++ b/app/models/destination.rb
@@ -9,5 +9,5 @@ class Destination < ApplicationRecord
   validates :city, presence: true
   validates :address, presence: true
 
-  belongs_to :user
+  belongs_to :user, optional: true
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -19,6 +19,5 @@ class User < ApplicationRecord
   has_many :items
   has_many :favorites, dependent: :destroy
   has_many :fav_items, through: :favorites, source: :item
-  # belongs_to :destination, optional: true
   has_one :destination
 end

--- a/app/views/devise/registrations/new.html.haml
+++ b/app/views/devise/registrations/new.html.haml
@@ -4,7 +4,7 @@
     .AccountPage__title
       %h2 会員情報入力
     .AccountPage__form
-      = form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f|      
+      = form_for(@user, url: user_registration_path) do |f|
         = render "devise/shared/error_messages", resource: @user
         .FormField
           .FormField__label--normal
@@ -52,7 +52,7 @@
             != sprintf(f.date_select(:birthday, prefix:'birthday', with_css_classes:'XXXXX', prompt:"--", use_month_numbers:true, start_year:Time.now.year, end_year:1960, date_separator:'%s'),'年','月')+'日'
 
         .actions
-          = f.submit "新規登録する", class: 'Button UserButton'
+          = f.submit "次へ", class: 'Button UserButton'
           = render "devise/shared/links"
   = render "devise/shared/footer"
 

--- a/app/views/devise/registrations/new_destination.html.haml
+++ b/app/views/devise/registrations/new_destination.html.haml
@@ -1,0 +1,61 @@
+.AccountContainer
+  = render 'devise/shared/header'
+  .AccountPage
+    .AccountPage__title
+      %h2 住所の登録
+    .AccountPage__form
+      = form_for(@destination, url: {controller: 'registrations', action: 'create_destination'}) do |f|
+        = render 'layouts/error_messages'
+        .FormField
+          .FormField__label--normal
+            = f.label "お名前（全角）"
+            %span.requiredLabel 必須
+          .FormField__input--normal.FormField--flex
+            = f.text_field :destination_family_name, placeholder: "姓（全角）"
+            = f.text_field :destination_first_name, placeholder: "名（全角）"
+        .FormField
+          .FormField__label--normal
+            = f.label "お名前カナ（全角）"
+            %span.requiredLabel 必須
+          .FormField__input--normal.FormField--flex
+            = f.text_field :destination_family_name_kana, placeholder: "姓カナ（全角）"
+            = f.text_field :destination_first_name_kana, placeholder: "名カナ（全角）"
+        .FormField
+          .FormField__label--normal
+            = f.label "郵便番号"
+            %span.requiredLabel 必須
+          .FormField__input--normal.FormField--flex
+            = f.text_field :post_code, placeholder: "例）100-9999"
+        .FormField
+          .FormField__label--normal
+            = f.label "都道府県"
+            %span.requiredLabel 必須
+          .FormField__input--normal.FormField--flex
+            = f.text_field :prefecture, placeholder: "例）東京都"
+        .FormField
+          .FormField__label--normal
+            = f.label "市区町村"
+            %span.requiredLabel 必須
+          .FormField__input--normal.FormField--flex
+            = f.text_field :city, placeholder: "例）中央区丸の内"
+        .FormField
+          .FormField__label--normal
+            = f.label "番地"
+            %span.requiredLabel 必須
+          .FormField__input--normal.FormField--flex
+            = f.text_field :address, placeholder: "1-2-3"
+        .FormField
+          .FormField__label--normal
+            = f.label "建物名（任意）"
+          .FormField__input--normal.FormField--flex
+            = f.text_field :building_name, placeholder: "例）新東京ビル"
+        .FormField
+          .FormField__label--normal
+            = f.label "電話番号（任意）"
+          .FormField__input--normal.FormField--flex
+            = f.text_field :phone_number, placeholder: "03-1111-9999"
+                  
+        .actions
+          = f.submit "新規登録する", class: 'Button UserButton'
+          = link_to "トップへ戻る", root_path, method: :get, class: 'Button'
+  = render "devise/shared/footer"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,11 @@
 Rails.application.routes.draw do
-  devise_for :users
+  devise_for :users, controllers: {
+    registrations: 'users/registrations'
+  }
+  devise_scope :user do
+    get 'destination', to: 'users/registrations#new_destination'
+    post 'destination', to: 'users/registrations#create_destination'
+  end
   root 'items#index'
   resources :items, except: :new do
     collection do


### PR DESCRIPTION
# What
ユーザー新規登録時に配送先情報をウィザード形式で登録できるようにカスタマイズしました。
もともとは配送先情報はメルカリの仕様に合わせてマイページから登録できるようにしていましたが、
フリマの仕様に合わせてウィザード形式で登録できるようなモジュールを作成しました。

# Why
ユーザビリティ向上のため

# 動作確認動画
https://gyazo.com/6a6b8558587e5a8442021799bb16f1bd